### PR TITLE
Linter & husky fixes

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -6,26 +6,6 @@ on:
       - main
 
 jobs:
-  backend:
-    name: Backend check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-      - working-directory: backend
-        run: |
-          npm ci
-          npm run lint-check
-        env:
-          PORT: ${{ secrets.PORT }}
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
-          FRONTEND_ORIGIN: ${{ secrets.FRONTEND_ORIGIN }}
-          EMAIL_USER: ${{ secrets.EMAIL_USER }}
-          EMAIL_APP_PASSWORD: ${{ secrets.EMAIL_APP_PASSWORD }}
-          EMAIL_NOTIFICATIONS_RECIPIENT: ${{ secrets.EMAIL_NOTIFICATIONS_RECIPIENT }}
-          BACKEND_FIREBASE_SETTINGS: ${{ secrets.BACKEND_FIREBASE_SETTINGS }}
-          SERVICE_ACCOUNT_KEY: ${{ secrets.SERVICE_ACCOUNT_KEY }}
-
   frontend:
     name: Frontend check
     runs-on: ubuntu-latest

--- a/.husky/lint-config.sh
+++ b/.husky/lint-config.sh
@@ -5,7 +5,7 @@
 enabled=1
 
 # Directories containing JavaScript projects to be linted, separated by spaces.
-node_dirs='backend frontend'
+node_dirs='frontend'
 
 # Command used to run a lint check.
 check_command='npm run lint-check'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,7 +56,8 @@
         "eslint-plugin-no-relative-import-paths": "^1.5.3",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "husky": "^8.0.3",
+        "eslint-plugin-react-refresh": "^0.4.18",
+        "husky": "^9.1.7",
         "prettier": "^3.4.2",
         "typescript": "~5.2.0"
       }
@@ -5933,6 +5934,16 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.18.tgz",
+      "integrity": "sha512-IRGEoFn3OKalm3hjfolEWGqoF/jPqeEYFp+C8B0WMzwGwBMvlRDQd06kghDhF0C61uJ6WfSDhEZE/sAQjduKgw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -6971,16 +6982,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,8 @@
     "eslint-plugin-no-relative-import-paths": "^1.5.3",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "husky": "^8.0.3",
+    "eslint-plugin-react-refresh": "^0.4.18",
+    "husky": "^9.1.7",
     "prettier": "^3.4.2",
     "typescript": "~5.2.0"
   }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,7 @@
-import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+
+import type { Metadata } from "next";
+
 import "@/app/globals.css";
 const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-import styles from "@/app/page.module.css";
 export default function Home() {
   return (
     <main>


### PR DESCRIPTION
This PR fixes some issues with the CI/CD lint checks (e.g. they are failing on https://github.com/TritonSE/SpayLA-Website/pull/24). It includes the following changes:
1. Remove the "Backend check" job from `lint-check.yml`, since this project has no backend
2. Fixes `.husky/lint-config` to not run linters in the nonexistent `backend` directory
3. Update husky version from 8 to 9 since it's not working correctly with version 8, and all our other projects this year are using version 9
4. Install `eslint-plugin-react-refresh` plugin since it's used in the lint config
5. Fix some linter errors (unused imports, import order, lines between imports)